### PR TITLE
bindings: add support for batch parameter

### DIFF
--- a/binding.cpp
+++ b/binding.cpp
@@ -162,7 +162,7 @@ void llama_free_params(void* params_ptr) {
 
 
 void* llama_allocate_params(const char *prompt, int seed, int threads, int tokens, int top_k,
-                            float top_p, float temp, float repeat_penalty, int repeat_last_n, bool ignore_eos, bool memory_f16) {
+                            float top_p, float temp, float repeat_penalty, int repeat_last_n, bool ignore_eos, bool memory_f16, int n_batch) {
     gpt_params* params = new gpt_params;
     params->seed = seed;
     params->n_threads = threads;
@@ -174,6 +174,7 @@ void* llama_allocate_params(const char *prompt, int seed, int threads, int token
     params->memory_f16 = memory_f16;
     params->temp = temp;
     params->repeat_penalty = repeat_penalty;
+    params->n_batch = n_batch;
 
     params->prompt = prompt;
     params->ignore_eos = ignore_eos;

--- a/binding.h
+++ b/binding.h
@@ -7,7 +7,7 @@ extern "C" {
 void* load_model(const char *fname, int n_ctx, int n_parts, int n_seed, bool memory_f16, bool mlock);
 
 void* llama_allocate_params(const char *prompt, int seed, int threads, int tokens,
-                            int top_k, float top_p, float temp, float repeat_penalty, int repeat_last_n, bool ignore_eos, bool memory_f16);
+                            int top_k, float top_p, float temp, float repeat_penalty, int repeat_last_n, bool ignore_eos, bool memory_f16, int n_batch);
 
 void llama_free_params(void* params_ptr);
 

--- a/llama.go
+++ b/llama.go
@@ -40,7 +40,7 @@ func (l *LLama) Predict(text string, opts ...PredictOption) (string, error) {
 	out := make([]byte, po.Tokens)
 
 	params := C.llama_allocate_params(input, C.int(po.Seed), C.int(po.Threads), C.int(po.Tokens), C.int(po.TopK),
-		C.float(po.TopP), C.float(po.Temperature), C.float(po.Penalty), C.int(po.Repeat), C.bool(po.IgnoreEOS), C.bool(po.F16KV))
+		C.float(po.TopP), C.float(po.Temperature), C.float(po.Penalty), C.int(po.Repeat), C.bool(po.IgnoreEOS), C.bool(po.F16KV), C.int(po.Batch))
 	ret := C.llama_predict(params, l.state, (*C.char)(unsafe.Pointer(&out[0])))
 	if ret != 0 {
 		return "", fmt.Errorf("inference failed")

--- a/options.go
+++ b/options.go
@@ -11,10 +11,10 @@ type ModelOptions struct {
 }
 
 type PredictOptions struct {
-	Seed, Threads, Tokens, TopK, Repeat int
-	TopP, Temperature, Penalty          float64
-	F16KV                               bool
-	IgnoreEOS                           bool
+	Seed, Threads, Tokens, TopK, Repeat, Batch int
+	TopP, Temperature, Penalty                 float64
+	F16KV                                      bool
+	IgnoreEOS                                  bool
 }
 
 type PredictOption func(p *PredictOptions)
@@ -36,6 +36,7 @@ var DefaultOptions PredictOptions = PredictOptions{
 	Temperature: 0.96,
 	Penalty:     1,
 	Repeat:      64,
+	Batch:       8,
 }
 
 // SetContext sets the context size.
@@ -135,6 +136,13 @@ func SetPenalty(penalty float64) PredictOption {
 func SetRepeat(repeat int) PredictOption {
 	return func(p *PredictOptions) {
 		p.Repeat = repeat
+	}
+}
+
+// SetBatch sets the batch size.
+func SetBatch(size int) PredictOption {
+	return func(p *PredictOptions) {
+		p.Batch = size
 	}
 }
 


### PR DESCRIPTION
This PR adds support for the `n_batch` parameter used in llama.cpp 

https://github.com/ggerganov/llama.cpp/blob/master/examples/common.h#L23