### PR TITLE
Add support for setting n_keep param

### DIFF
--- a/binding.cpp
+++ b/binding.cpp
@@ -162,7 +162,7 @@ void llama_free_params(void* params_ptr) {
 
 
 void* llama_allocate_params(const char *prompt, int seed, int threads, int tokens, int top_k,
-                            float top_p, float temp, float repeat_penalty, int repeat_last_n, bool ignore_eos, bool memory_f16, int n_batch) {
+                            float top_p, float temp, float repeat_penalty, int repeat_last_n, bool ignore_eos, bool memory_f16, int n_batch, int n_keep) {
     gpt_params* params = new gpt_params;
     params->seed = seed;
     params->n_threads = threads;
@@ -175,6 +175,7 @@ void* llama_allocate_params(const char *prompt, int seed, int threads, int token
     params->temp = temp;
     params->repeat_penalty = repeat_penalty;
     params->n_batch = n_batch;
+    params->n_keep = n_keep;
 
     params->prompt = prompt;
     params->ignore_eos = ignore_eos;

--- a/binding.h
+++ b/binding.h
@@ -7,7 +7,9 @@ extern "C" {
 void* load_model(const char *fname, int n_ctx, int n_parts, int n_seed, bool memory_f16, bool mlock);
 
 void* llama_allocate_params(const char *prompt, int seed, int threads, int tokens,
-                            int top_k, float top_p, float temp, float repeat_penalty, int repeat_last_n, bool ignore_eos, bool memory_f16, int n_batch);
+                            int top_k, float top_p, float temp, float repeat_penalty, 
+                            int repeat_last_n, bool ignore_eos, bool memory_f16, 
+                            int n_batch, int n_keep);
 
 void llama_free_params(void* params_ptr);
 

--- a/llama.go
+++ b/llama.go
@@ -40,7 +40,10 @@ func (l *LLama) Predict(text string, opts ...PredictOption) (string, error) {
 	out := make([]byte, po.Tokens)
 
 	params := C.llama_allocate_params(input, C.int(po.Seed), C.int(po.Threads), C.int(po.Tokens), C.int(po.TopK),
-		C.float(po.TopP), C.float(po.Temperature), C.float(po.Penalty), C.int(po.Repeat), C.bool(po.IgnoreEOS), C.bool(po.F16KV), C.int(po.Batch))
+		C.float(po.TopP), C.float(po.Temperature), C.float(po.Penalty), C.int(po.Repeat), 
+		C.bool(po.IgnoreEOS), C.bool(po.F16KV),
+		C.int(po.Batch), C.int(po.NKeep),
+	)
 	ret := C.llama_predict(params, l.state, (*C.char)(unsafe.Pointer(&out[0])))
 	if ret != 0 {
 		return "", fmt.Errorf("inference failed")

--- a/options.go
+++ b/options.go
@@ -11,7 +11,7 @@ type ModelOptions struct {
 }
 
 type PredictOptions struct {
-	Seed, Threads, Tokens, TopK, Repeat, Batch int
+	Seed, Threads, Tokens, TopK, Repeat, Batch, NKeep int
 	TopP, Temperature, Penalty                 float64
 	F16KV                                      bool
 	IgnoreEOS                                  bool
@@ -37,6 +37,7 @@ var DefaultOptions PredictOptions = PredictOptions{
 	Penalty:     1,
 	Repeat:      64,
 	Batch:       8,
+	NKeep:       64,
 }
 
 // SetContext sets the context size.
@@ -143,6 +144,13 @@ func SetRepeat(repeat int) PredictOption {
 func SetBatch(size int) PredictOption {
 	return func(p *PredictOptions) {
 		p.Batch = size
+	}
+}
+
+// SetKeep sets the number of tokens from initial prompt to keep.
+func SetNKeep(n int) PredictOption {
+	return func(p *PredictOptions) {
+		p.NKeep = n
 	}
 }
 


### PR DESCRIPTION
Expose the n_keep parameter to the go bindings. This param allows you to configure how many tokens from the initial prompt are maintained across subsequent messages. Setting to -1 keeps the entire prompt and can help the bot keep the conversation consistent.