### PR TITLE
Implemented callback for individual tokens

### DIFF
--- a/binding.cpp
+++ b/binding.cpp
@@ -126,6 +126,14 @@ int llama_predict(void* params_ptr, void* state_pr, char* result, bool debug) {
 
             // decrement remaining sampling budget
             --n_remain;
+
+
+            // call the token callback, no need to check if one is actually registered, that will
+            // be handled on the Go side.
+            auto token_str = llama_token_to_str(ctx, id);
+            if (!tokenCallback(state_pr, (char*)token_str)) {
+                break;
+            }
         } else {
             // some user input remains from prompt or interaction, forward it to processing
             while ((int) embd_inp.size() > n_consumed) {

--- a/binding.h
+++ b/binding.h
@@ -6,6 +6,8 @@ extern "C" {
 
 #include <stdbool.h>
 
+extern unsigned char tokenCallback(void *, char *);
+
 void* load_model(const char *fname, int n_ctx, int n_parts, int n_seed, bool memory_f16, bool mlock);
 
 void* llama_allocate_params(const char *prompt, int seed, int threads, int tokens,

--- a/examples/main.go
+++ b/examples/main.go
@@ -39,14 +39,19 @@ func main() {
 
 	reader := bufio.NewReader(os.Stdin)
 
+	l.SetTokenCallback(func(token string) bool {
+		fmt.Print(token)
+		return true
+	})
+
 	for {
 		text := readMultiLineInput(reader)
 
-		res, err := l.Predict(text, llama.Debug, llama.SetTokens(tokens), llama.SetThreads(threads), llama.SetTopK(90), llama.SetTopP(0.86), llama.SetStopWords("llama"))
+		fmt.Printf("\ngolang: ")
+		_, err := l.Predict(text, llama.Debug, llama.SetTokens(tokens), llama.SetThreads(threads), llama.SetTopK(90), llama.SetTopP(0.86), llama.SetStopWords("llama"))
 		if err != nil {
 			panic(err)
 		}
-		fmt.Printf("\ngolang: %s\n", res)
 
 		fmt.Printf("\n\n")
 	}


### PR DESCRIPTION
This PR adds the functionality to set a callback for the predicted tokens. The callback will be called after a token has been predicted. The callback must return `true` if the model should predict more tokens or `false` if it should stop.

You can call `l.SetTokenCallback(callback)` to register the callback and `l.SetTokenCallback(nil)` to deregister it. Only one callback can be registered per `*LLama` instance but different instances can use different callbacks. The callbacks are also thread-safe, you can (de-)register them freely while the model is predicting.

Solves #4 