### PR TITLE
Small fix in make file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ $(info I CXX:      $(CXXV))
 $(info )
 
 llama.cpp/ggml.o:
-	mkdir build
+	mkdir -p build
 	cd build && cmake ../llama.cpp $(CMAKE_ARGS) && make VERBOSE=1 ggml && cp -rf CMakeFiles/ggml.dir/ggml.c.o ../llama.cpp/ggml.o
 
 llama.cpp/llama.o:


### PR DESCRIPTION
When I tried `make libbinding.a` it exited with error because i haven't had `cmake` installed.

After Installed it i couldn't rebuild because of:

```
mkdir build
mkdir: build: File exists
make: *** [llama.cpp/ggml.o] Error 1
```

So I suggest to add `-p` flag to make file so will create `build` dir only if it doesn't exist