### PR TITLE
use context size from model when loading last session

### DIFF
--- a/binding.cpp
+++ b/binding.cpp
@@ -117,6 +117,8 @@ int llama_predict(void* params_ptr, void* state_pr, char* result, bool debug) {
   
     gpt_params params = *params_p;
 
+    const int n_ctx = llama_n_ctx(ctx);
+
     if (params.seed <= 0) {
         params.seed = time(NULL);
     }
@@ -125,7 +127,7 @@ int llama_predict(void* params_ptr, void* state_pr, char* result, bool debug) {
 
     llama_init_backend();
 
-        std::string path_session = params.path_prompt_cache;
+    std::string path_session = params.path_prompt_cache;
     std::vector<llama_token> session_tokens;
 
     if (!path_session.empty()) {
@@ -137,7 +139,7 @@ int llama_predict(void* params_ptr, void* state_pr, char* result, bool debug) {
         if (fp != NULL) {
             std::fclose(fp);
 
-            session_tokens.resize(params.n_ctx);
+            session_tokens.resize(n_ctx);
             size_t n_token_count_out = 0;
             if (!llama_load_session_file(ctx, path_session.c_str(), session_tokens.data(), session_tokens.capacity(), &n_token_count_out)) {
                 fprintf(stderr, "%s: error: failed to load session file '%s'\n", __func__, path_session.c_str());
@@ -164,8 +166,6 @@ int llama_predict(void* params_ptr, void* state_pr, char* result, bool debug) {
     } else {
         embd_inp = session_tokens;
     }
-
-    const int n_ctx = llama_n_ctx(ctx);
 
     // debug message about similarity of saved session, if applicable
     size_t n_matching_session_tokens = 0;


### PR DESCRIPTION
## **Describe the bug**
llama.cpp cache/session file cannot be loaded due to small capacity.

I'm trying to use the new cache feature in order to speed-up CPU inference, however I cannot get it to work using full context.

The default context size is set to 512 in [go-llama.cpp](https://github.com/go-skynet/go-llama.cpp/blob/master/options.go#L40) and it [should be overridden](https://github.com/go-skynet/LocalAI/blob/master/api/prediction.go#LL28C3-L28C3) by the model's context size, however that doesn't seem to be the case.

I have changed the C code to use the model's context size instead of using the parameters.

### **References**
* Original PR: #70 
* llama.cpp line no: https://github.com/ggerganov/llama.cpp/blob/7552ac586380f202b75b18aa216ecfefbd438d94/llama.cpp#L2844
