### PR TITLE
Fix for #80 Metal Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ llama.cpp/ggml-cuda.o: llama.cpp/ggml.o
 llama.cpp/ggml-opencl.o: llama.cpp/ggml.o
 	cd build && cp -rf CMakeFiles/ggml.dir/ggml-opencl.cpp.o ../llama.cpp/ggml-opencl.o
 
-llama.cpp/ggml-metal.o: llama.cpp/ggml.o
+llama.cpp/ggml-metal.o: llama.cpp/ggml-metal.o
 	cd build && cp -rf CMakeFiles/ggml.dir/ggml-metal.m.o ../llama.cpp/ggml-metal.o
 
 llama.cpp/ggml-quants.o: llama.cpp/ggml.o


### PR DESCRIPTION
i noticed the makefile maps the incorrect output file for llama.cpp.  here is a quick fix and is working fine on my ci macos arm now