### PR TITLE
Add a base gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# build files
+/binding.o
+/build
+/ggml-metal.metal
+/libbinding.a
+
+# just in case
+.DS_Store
+.idea
+.vscode
+Thumbs.db


### PR DESCRIPTION
This allows us to use git add without worrying about accidentally including build files.