### PR TITLE
fix: safer loop bounds for TokenizeString, update golang to 1.21

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,42 +4,68 @@ on: [pull_request]
 jobs:
   ubuntu-latest:
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        go-version: [ '1.21', '1.21.x' ]
     steps:
       - name: Clone
         uses: actions/checkout@v3
         with: 
           submodules: true
+        run: go version
       - name: Dependencies
         run: |
           sudo apt-get update
           sudo apt-get install build-essential
+      - name: Setup Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go-version }}
+      # You can test your matrix by printing the current Go version
+      - name: Display Go version
+        run: go version
       - name: Test
         run: |
           make test
 
   macOS-latest:
     runs-on: macOS-latest
-
+    strategy:
+      matrix:
+        go-version: [ '1.21', '1.21.x' ]
     steps:
       - name: Clone
         uses: actions/checkout@v3
         with: 
           submodules: true
-
+      - name: Setup Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go-version }}
+      # You can test your matrix by printing the current Go version
+      - name: Display Go version
+        run: go version
       - name: Test
         run: |
           CMAKE_ARGS="-DLLAMA_F16C=OFF -DLLAMA_AVX512=OFF -DLLAMA_AVX2=OFF -DLLAMA_FMA=OFF" make test
 
   macOS-metal-latest:
     runs-on: macOS-latest
-
+    strategy:
+      matrix:
+        go-version: [ '1.21', '1.21.x' ]
     steps:
       - name: Clone
         uses: actions/checkout@v3
         with: 
           submodules: true
-
+      - name: Setup Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go-version }}
+      # You can test your matrix by printing the current Go version
+      - name: Display Go version
+        run: go version
       - name: Test
         run: |
           CMAKE_ARGS="-DLLAMA_F16C=OFF -DLLAMA_AVX512=OFF -DLLAMA_AVX2=OFF -DLLAMA_FMA=OFF" make BUILD_TYPE=metal test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,6 @@ jobs:
         uses: actions/checkout@v3
         with: 
           submodules: true
-        run: go version
       - name: Dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.21', '1.21.x' ]
+        go-version: ['1.21.x', 'stable ']
     steps:
       - name: Clone
         uses: actions/checkout@v3
@@ -31,7 +31,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        go-version: [ '1.21', '1.21.x' ]
+        go-version: ['1.21.x', 'stable ']
     steps:
       - name: Clone
         uses: actions/checkout@v3
@@ -52,7 +52,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        go-version: [ '1.21.x', 'stable ' ]
+        go-version: ['1.21.x', 'stable ']
     steps:
       - name: Clone
         uses: actions/checkout@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,7 +52,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        go-version: [ '1.21', '1.21.x' ]
+        go-version: [ '1.21.x', 'stable ' ]
     steps:
       - name: Clone
         uses: actions/checkout@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.21.x', 'stable ']
+        go-version: ['1.21.x', 'stable']
     steps:
       - name: Clone
         uses: actions/checkout@v3
@@ -31,7 +31,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        go-version: ['1.21.x', 'stable ']
+        go-version: ['1.21.x', 'stable']
     steps:
       - name: Clone
         uses: actions/checkout@v3
@@ -52,7 +52,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        go-version: ['1.21.x', 'stable ']
+        go-version: ['1.21.x', 'stable']
     steps:
       - name: Clone
         uses: actions/checkout@v3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-skynet/go-llama.cpp
 
-go 1.19
+go 1.21
 
 require (
 	github.com/onsi/ginkgo/v2 v2.11.0

--- a/llama.go
+++ b/llama.go
@@ -24,7 +24,7 @@ type LLama struct {
 func New(model string, opts ...ModelOption) (*LLama, error) {
 	mo := NewModelOptions(opts...)
 	modelPath := C.CString(model)
-	defer C.free(unsafe.Pointer(modelPath)) 
+	defer C.free(unsafe.Pointer(modelPath))
 	result := C.load_model(modelPath,
 		C.int(mo.ContextSize), C.int(mo.Seed),
 		C.bool(mo.F16Memory), C.bool(mo.MLock), C.bool(mo.Embeddings), C.bool(mo.MMap), C.bool(mo.LowVRAM),
@@ -32,7 +32,7 @@ func New(model string, opts ...ModelOption) (*LLama, error) {
 		C.float(mo.FreqRopeBase), C.float(mo.FreqRopeScale),
 		C.float(mo.RMSNormEPS), C.int(mo.GQA),
 	)
-	
+
 	if result == nil {
 		return nil, fmt.Errorf("failed loading model")
 	}
@@ -50,8 +50,8 @@ func (l *LLama) LoadState(state string) error {
 	w := C.CString("rb")
 	result := C.load_state(l.state, d, w)
 
-	defer C.free(unsafe.Pointer(d))  // free allocated C string
-	defer C.free(unsafe.Pointer(w))  // free allocated C string
+	defer C.free(unsafe.Pointer(d)) // free allocated C string
+	defer C.free(unsafe.Pointer(w)) // free allocated C string
 
 	if result != 0 {
 		return fmt.Errorf("error while loading state")
@@ -66,9 +66,9 @@ func (l *LLama) SaveState(dst string) error {
 
 	C.save_state(l.state, d, w)
 
-	defer C.free(unsafe.Pointer(d))  // free allocated C string
-	defer C.free(unsafe.Pointer(w))  // free allocated C string
-	
+	defer C.free(unsafe.Pointer(d)) // free allocated C string
+	defer C.free(unsafe.Pointer(w)) // free allocated C string
+
 	_, err := os.Stat(dst)
 	return err
 }
@@ -293,8 +293,11 @@ func (l *LLama) TokenizeString(text string, opts ...PredictOption) (int32, []int
 
 	// TODO: Is this loop still required to unbox cgo to go?
 	gTokRet := int32(tokRet)
-	goSlice := make([]int32, gTokRet)
-	for i := int32(0); i < gTokRet; i++ {
+
+	gLenOut := min(len(out), int(gTokRet))
+
+	goSlice := make([]int32, gLenOut)
+	for i := 0; i < gLenOut; i++ {
 		goSlice[i] = int32(out[i])
 	}
 


### PR DESCRIPTION
Still do not know how to reproduce Luna's crash, but the most likely cause is this loop.

- Bump golang version to 1.21 for `min()` builtin
- Use the smaller of the returned length and the actual length of the returned token slice
- Since the returned length might be negative in error cases, this gives us a free way to skip the for loop as well, since -N < 0. 