### PR TITLE
feat(speculative-sampling): add grammar support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,7 +46,7 @@ jobs:
         run: go version
       - name: Test
         run: |
-          CMAKE_ARGS="-DLLAMA_F16C=OFF -DLLAMA_AVX512=OFF -DLLAMA_AVX2=OFF -DLLAMA_FMA=OFF" make test
+          CMAKE_ARGS="-DLLAMA_METAL=OFF -DLLAMA_F16C=OFF -DLLAMA_AVX512=OFF -DLLAMA_AVX2=OFF -DLLAMA_FMA=OFF" make test
 
   macOS-metal-latest:
     runs-on: macOS-latest


### PR DESCRIPTION
Adds support for: https://github.com/ggerganov/llama.cpp/pull/2991 (copying the required bits from the llama.cpp example)

part of https://github.com/go-skynet/LocalAI/issues/1013

Note from this version METAL is enabled by default on mac builds and as such needs to be disabled specifically in case it is not wanted (https://github.com/ggerganov/llama.cpp/pull/2901)