### PR TITLE
fix(cuda): workaround sigsegv

### DIFF
--- a/binding.cpp
+++ b/binding.cpp
@@ -970,12 +970,14 @@ gpt_params* create_gpt_params(const std::string& fname,const std::string& lora,c
 
     // Initialize the 'model' member with the 'fname' parameter
     lparams->model = fname;
+// Temporary workaround for https://github.com/go-skynet/go-llama.cpp/issues/218
+#ifndef GGML_USE_CUBLAS
     lparams->lora_base = lora_base;
     lparams->lora_adapter = lora;
     if (lparams->lora_adapter.empty()) {
         lparams->use_mmap = false;
     }
-
+#endif
     return lparams;
 }
 

--- a/patches/1902-cuda.patch
+++ b/patches/1902-cuda.patch
@@ -1,8 +1,8 @@
 diff --git a/common/common.cpp b/common/common.cpp
-index d4f9dbf..4edc500 100644
+index d4f9dbf..9a01627 100644
 --- a/common/common.cpp
 +++ b/common/common.cpp
-@@ -1259,3 +1259,85 @@ void dump_non_result_info_yaml(FILE * stream, const gpt_params & params, const l
+@@ -1259,3 +1259,97 @@ void dump_non_result_info_yaml(FILE * stream, const gpt_params & params, const l
      fprintf(stream, "typical_p: %f # default: 1.0\n", params.typical_p);
      fprintf(stream, "verbose_prompt: %s # default: false\n", params.verbose_prompt ? "true" : "false");
  }
@@ -13,20 +13,32 @@ index d4f9dbf..4edc500 100644
 +
 +    // Initialize the 'model' member with the 'fname' parameter
 +    lparams->model = fname;
-+// Temporary workaround for https://github.com/go-skynet/go-llama.cpp/issues/218
-+#ifndef GGML_USE_CUBLAS
 +    lparams->lora_base = lora_base;
 +    lparams->lora_adapter = lora;
 +    if (lparams->lora_adapter.empty()) {
 +        lparams->use_mmap = false;
 +    }
-+#endif
++    return lparams;
++}
++
++gpt_params* create_gpt_params_cuda(const std::string& fname) {
++   gpt_params* lparams = new gpt_params;
++    fprintf(stderr, "%s: loading model %s\n", __func__, fname.c_str());
++
++    // Initialize the 'model' member with the 'fname' parameter
++    lparams->model = fname;
 +    return lparams;
 +}
 +
 +void* load_binding_model(const char *fname, int n_ctx, int n_seed, bool memory_f16, bool mlock, bool embeddings, bool mmap, bool low_vram, int n_gpu_layers, int n_batch, const char *maingpu, const char *tensorsplit, bool numa,  float rope_freq_base, float rope_freq_scale, bool mul_mat_q, const char *lora, const char *lora_base, bool perplexity) {
 +    // load the model
-+    gpt_params * lparams = create_gpt_params(fname, lora, lora_base);
++    gpt_params * lparams;
++// Temporary workaround for https://github.com/go-skynet/go-llama.cpp/issues/218
++#ifdef GGML_USE_CUBLAS
++    lparams = create_gpt_params_cuda(fname);
++#else
++    lparams = create_gpt_params(fname, lora, lora_base);
++#endif
 +    llama_model * model;
 +    llama_binding_state * state;
 +    state = new llama_binding_state;

--- a/patches/1902-cuda.patch
+++ b/patches/1902-cuda.patch
@@ -1,8 +1,8 @@
 diff --git a/common/common.cpp b/common/common.cpp
-index 3138213..af93a32 100644
+index d4f9dbf..4edc500 100644
 --- a/common/common.cpp
 +++ b/common/common.cpp
-@@ -1257,3 +1257,83 @@ void dump_non_result_info_yaml(FILE * stream, const gpt_params & params, const l
+@@ -1259,3 +1259,85 @@ void dump_non_result_info_yaml(FILE * stream, const gpt_params & params, const l
      fprintf(stream, "typical_p: %f # default: 1.0\n", params.typical_p);
      fprintf(stream, "verbose_prompt: %s # default: false\n", params.verbose_prompt ? "true" : "false");
  }
@@ -13,12 +13,14 @@ index 3138213..af93a32 100644
 +
 +    // Initialize the 'model' member with the 'fname' parameter
 +    lparams->model = fname;
++// Temporary workaround for https://github.com/go-skynet/go-llama.cpp/issues/218
++#ifndef GGML_USE_CUBLAS
 +    lparams->lora_base = lora_base;
 +    lparams->lora_adapter = lora;
 +    if (lparams->lora_adapter.empty()) {
 +        lparams->use_mmap = false;
 +    }
-+
++#endif
 +    return lparams;
 +}
 +
@@ -88,7 +90,7 @@ index 3138213..af93a32 100644
 +}
 \ No newline at end of file
 diff --git a/common/common.h b/common/common.h
-index 105fb09..8f60434 100644
+index 85ac0df..eb9d24b 100644
 --- a/common/common.h
 +++ b/common/common.h
 @@ -201,3 +201,10 @@ std::string get_sortable_timestamp();


### PR DESCRIPTION
See: #218

This was introduced in #14 

This is just a dummy workaround to avoid the binding to crash entirely - it skips lora for cublas until we find a better workaround