### PR TITLE
Fix Stopwords/Antiprompt

### DIFF
--- a/binding.cpp
+++ b/binding.cpp
@@ -513,10 +513,16 @@ int llama_predict(void* params_ptr, void* state_pr, char* result, bool debug) {
                         : 0;
 
                     if (last_output.find(antiprompt, search_start_pos) != std::string::npos) {
+                        is_antiprompt = true;
                         break;
                     }
                 }
             }
+        }
+
+        // found antiprompt
+        if (is_antiprompt) {
+            break;
         }
       
         // end of text token


### PR DESCRIPTION
The original break was breaking out of the inner for loop, but not the outer while loop. Repurpose (?) the existing unused variable is_antiprompt to terminate the while loop if any antiprompt was found. We can still break out of the for loop, since we already found one antiprompt, finding others is not useful. Fixes  #183 