### PR TITLE
fix: add missing Makefile dependencies to allow for parallelized builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: test clean
+
 INCLUDE_PATH := $(abspath ./)
 LIBRARY_PATH := $(abspath ./)
 
@@ -199,10 +201,10 @@ $(info )
 
 # Use this if you want to set the default behavior
 
-llama.cpp/grammar-parser.o:
+llama.cpp/grammar-parser.o: llama.cpp/ggml.o
 	cd build && cp -rf common/CMakeFiles/common.dir/grammar-parser.cpp.o ../llama.cpp/grammar-parser.o
 
-llama.cpp/ggml-alloc.o:
+llama.cpp/ggml-alloc.o: llama.cpp/ggml.o
 	cd build && cp -rf CMakeFiles/ggml.dir/ggml-alloc.c.o ../llama.cpp/ggml-alloc.o
 
 llama.cpp/ggml.o: prepare
@@ -221,13 +223,13 @@ llama.cpp/ggml-metal.o: llama.cpp/ggml.o
 llama.cpp/k_quants.o: llama.cpp/ggml.o
 	cd build && cp -rf CMakeFiles/ggml.dir/k_quants.c.o ../llama.cpp/k_quants.o
 
-llama.cpp/llama.o:
+llama.cpp/llama.o: llama.cpp/ggml.o
 	cd build && cp -rf CMakeFiles/llama.dir/llama.cpp.o ../llama.cpp/llama.o
 
-llama.cpp/common.o:
+llama.cpp/common.o: llama.cpp/ggml.o
 	cd build && cp -rf common/CMakeFiles/common.dir/common.cpp.o ../llama.cpp/common.o
 
-binding.o: prepare llama.cpp/ggml.o llama.cpp/llama.o llama.cpp/common.o llama.cpp/grammar-parser.o llama.cpp/ggml-alloc.o
+binding.o: prepare
 	$(CXX) $(CXXFLAGS) -I./llama.cpp -I./llama.cpp/common binding.cpp -o binding.o -c $(LDFLAGS)
 
 ## https://github.com/ggerganov/llama.cpp/pull/1902
@@ -235,8 +237,8 @@ prepare:
 	cd llama.cpp && patch -p1 < ../patches/1902-cuda.patch
 	touch $@
 
-libbinding.a: prepare binding.o llama.cpp/k_quants.o llama.cpp/grammar-parser.o llama.cpp/ggml-alloc.o $(EXTRA_TARGETS)
-	ar src libbinding.a llama.cpp/ggml.o llama.cpp/k_quants.o $(EXTRA_TARGETS) llama.cpp/ggml-alloc.o llama.cpp/common.o llama.cpp/grammar-parser.o llama.cpp/llama.o binding.o
+libbinding.a: llama.cpp/ggml.o llama.cpp/k_quants.o llama.cpp/ggml-alloc.o llama.cpp/common.o llama.cpp/grammar-parser.o llama.cpp/llama.o binding.o $(EXTRA_TARGETS)
+	ar src libbinding.a llama.cpp/ggml.o llama.cpp/k_quants.o llama.cpp/ggml-alloc.o llama.cpp/common.o llama.cpp/grammar-parser.o llama.cpp/llama.o binding.o $(EXTRA_TARGETS)
 
 clean:
 	rm -rf *.o


### PR DESCRIPTION
When building LocalAI, it can be difficult to parallelize the build because some of the projects are missing required dependencies for their Makefile targets, this results in a race condition.  This PR adds the target dependencies that are missing for this project.